### PR TITLE
PR to yciabaud's PR – recursion!

### DIFF
--- a/lib/client/http-tracker.js
+++ b/lib/client/http-tracker.js
@@ -190,11 +190,11 @@ HTTPTracker.prototype._onAnnounceResponse = function (data) {
     self._trackerId = trackerId
   }
 
-  self.client.emit('update', {
+  var response = Object.assign({}, data, {
     announce: self.announceUrl,
-    complete: data.complete,
-    incomplete: data.incomplete
+    infoHash: common.binaryToHex(data.info_hash)
   })
+  self.client.emit('update', response)
 
   var addrs
   if (Buffer.isBuffer(data.peers)) {
@@ -248,15 +248,12 @@ HTTPTracker.prototype._onScrapeResponse = function (data) {
   }
 
   keys.forEach(function (infoHash) {
-    var response = data[infoHash]
     // TODO: optionally handle data.flags.min_request_interval
     // (separate from announce interval)
-    self.client.emit('scrape', {
+    var response = Object.assign(data[infoHash], {
       announce: self.announceUrl,
-      infoHash: common.binaryToHex(infoHash),
-      complete: response.complete,
-      incomplete: response.incomplete,
-      downloaded: response.downloaded
+      infoHash: common.binaryToHex(infoHash)
     })
+    self.client.emit('scrape', response)
   })
 }

--- a/lib/client/websocket-tracker.js
+++ b/lib/client/websocket-tracker.js
@@ -266,8 +266,11 @@ WebSocketTracker.prototype._onAnnounceResponse = function (data) {
   }
 
   if (data.complete != null) {
-    data.announce = self.announceUrl
-    self.client.emit('update', data)
+    var response = Object.assign({}, data, {
+      announce: self.announceUrl,
+      infoHash: common.binaryToHex(data.info_hash)
+    })
+    self.client.emit('update', response)
   }
 
   var peer
@@ -323,16 +326,13 @@ WebSocketTracker.prototype._onScrapeResponse = function (data) {
   }
 
   keys.forEach(function (infoHash) {
-    var response = data[infoHash]
     // TODO: optionally handle data.flags.min_request_interval
     // (separate from announce interval)
-    self.client.emit('scrape', {
+    var response = Object.assign(data[infoHash], {
       announce: self.announceUrl,
-      infoHash: common.binaryToHex(infoHash),
-      complete: response.complete,
-      incomplete: response.incomplete,
-      downloaded: response.downloaded
+      infoHash: common.binaryToHex(infoHash)
     })
+    self.client.emit('scrape', response)
   })
 }
 

--- a/server.js
+++ b/server.js
@@ -280,6 +280,8 @@ function Server (opts) {
   }
 }
 
+Server.Swarm = Swarm
+
 Server.prototype._onError = function (err) {
   var self = this
   self.emit('error', err)
@@ -352,7 +354,7 @@ Server.prototype.createSwarm = function (infoHash, cb) {
   if (Buffer.isBuffer(infoHash)) infoHash = infoHash.toString('hex')
 
   process.nextTick(function () {
-    var swarm = self.torrents[infoHash] = new Swarm(infoHash, self)
+    var swarm = self.torrents[infoHash] = new Server.Swarm(infoHash, self)
     cb(null, swarm)
   })
 }

--- a/server.js
+++ b/server.js
@@ -27,15 +27,14 @@ inherits(Server, EventEmitter)
  * metrics from clients that help the tracker keep overall statistics about the torrent.
  * Responses include a peer list that helps the client participate in the torrent.
  *
- * @param {Object}  opts                  options object
- * @param {Number}  opts.interval         tell clients to announce on this interval (ms)
- * @param {Number}  opts.trustProxy       trust 'x-forwarded-for' header from reverse proxy
- * @param {boolean} opts.http             start an http server? (default: true)
- * @param {boolean} opts.udp              start a udp server? (default: true)
- * @param {boolean} opts.ws               start a websocket server? (default: true)
- * @param {boolean} opts.stats            enable web-based statistics? (default: true)
- * @param {function} opts.filter          black/whitelist fn for disallowing/allowing torrents
- * @param {function} opts.requestHandler  functions to handle params / response
+ * @param {Object}  opts            options object
+ * @param {Number}  opts.interval   tell clients to announce on this interval (ms)
+ * @param {Number}  opts.trustProxy trust 'x-forwarded-for' header from reverse proxy
+ * @param {boolean} opts.http       start an http server? (default: true)
+ * @param {boolean} opts.udp        start a udp server? (default: true)
+ * @param {boolean} opts.ws         start a websocket server? (default: true)
+ * @param {boolean} opts.stats      enable web-based statistics? (default: true)
+ * @param {function} opts.filter    black/whitelist fn for disallowing/allowing torrents
  */
 function Server (opts) {
   var self = this
@@ -64,18 +63,6 @@ function Server (opts) {
   self.udp4 = null
   self.udp6 = null
   self.ws = null
-
-  self._reqHandler = opts.requestHandler || {}
-  if (!self._reqHandler.getParams) {
-    self._reqHandler.getParams = function (params) {
-      return params
-    }
-  }
-  if (!self._reqHandler.getResponse) {
-    self._reqHandler.getResponse = function (params, cb) {
-      return cb
-    }
-  }
 
   // start an http tracker unless the user explictly says no
   if (opts.http !== false) {
@@ -649,8 +636,6 @@ Server.prototype._onWebSocketError = function (socket, err) {
 
 Server.prototype._onRequest = function (params, cb) {
   var self = this
-  params = self._reqHandler.getParams(params)
-  cb = self._reqHandler.getResponse(params, cb)
   if (params && params.action === common.ACTIONS.CONNECT) {
     cb(null, { action: common.ACTIONS.CONNECT })
   } else if (params && params.action === common.ACTIONS.ANNOUNCE) {

--- a/test/request-handler.js
+++ b/test/request-handler.js
@@ -59,10 +59,8 @@ test('http: request handler option intercepts announce requests and responses', 
   testRequestHandler(t, 'http')
 })
 
-test('udp: request handler option intercepts announce requests and responses', function (t) {
-  testRequestHandler(t, 'udp')
-})
-
 test('ws: request handler option intercepts announce requests and responses', function (t) {
   testRequestHandler(t, 'ws')
 })
+
+// NOTE: it's not possible to include extra data in a UDP response, because it's compact and accepts only params that are in the spec!


### PR DESCRIPTION
- do not filter out extra keys from 'update' or 'scrape' events, in WS and HTTP
- remove requestHandler option
- expose Swarm object for easy overriding
- test: remove UDP request handler test -- not possible
- test: change request handler test to new approach